### PR TITLE
2019-12-06 GUARD-254 Purchase-Orders-Sync

### DIFF
--- a/src/NetSuiteAccess/Models/Commands/GetModifiedPurchaseOrdersCommand.cs
+++ b/src/NetSuiteAccess/Models/Commands/GetModifiedPurchaseOrdersCommand.cs
@@ -5,12 +5,12 @@ using System.Globalization;
 
 namespace NetSuiteAccess.Models.Commands
 {
-	public sealed class GetModifiedSalesOrdersCommand : NetSuiteCommand
+	public class GetModifiedPurchaseOrdersCommand : NetSuiteCommand
 	{
 		public DateTime StartDate { get; private set; }
 		public DateTime EndDate { get; private set; }
 
-		public GetModifiedSalesOrdersCommand( NetSuiteConfig config, DateTime startDate, DateTime endDate ) : base( config, "/rest/platform/v1/record/salesorder" )
+		public GetModifiedPurchaseOrdersCommand( NetSuiteConfig config, DateTime startDate, DateTime endDate ) : base( config, "/rest/platform/v1/record/purchaseorder" )
 		{
 			Condition.Requires( startDate, "startDate" ).IsLessThan( endDate );
 

--- a/src/NetSuiteAccess/Models/Commands/GetPurchaseOrderCommand.cs
+++ b/src/NetSuiteAccess/Models/Commands/GetPurchaseOrderCommand.cs
@@ -1,0 +1,18 @@
+﻿using CuttingEdge.Conditions;
+using NetSuiteAccess.Configuration;
+
+namespace NetSuiteAccess.Models.Commands
+{
+	public class GetPurchaseOrderCommand : NetSuiteCommand
+	{
+		public long OrderId { get; private set; }
+
+		public GetPurchaseOrderCommand( NetSuiteConfig config, long orderId ) : base( config, "/rest/platform/v1/record/purchaseorder" )
+		{
+			Condition.Requires( orderId, "orderId" ).IsGreaterThan( 0 );
+
+			this.OrderId = orderId;
+			this.Url = string.Format( "{0}/{1}?expandSubResources=true", this.RelativeUrl, this.OrderId );
+		}
+	}
+}

--- a/src/NetSuiteAccess/Models/Commands/GetSalesOrderCommand.cs
+++ b/src/NetSuiteAccess/Models/Commands/GetSalesOrderCommand.cs
@@ -3,11 +3,11 @@ using NetSuiteAccess.Configuration;
 
 namespace NetSuiteAccess.Models.Commands
 {
-	public class GetOrderCommand : NetSuiteCommand
+	public class GetSalesOrderCommand : NetSuiteCommand
 	{
 		public long OrderId { get; private set; }
 
-		public GetOrderCommand( NetSuiteConfig config, long orderId ) : base( config, "/rest/platform/v1/record/salesorder" )
+		public GetSalesOrderCommand( NetSuiteConfig config, long orderId ) : base( config, "/rest/platform/v1/record/salesorder" )
 		{
 			Condition.Requires( orderId, "orderId" ).IsGreaterThan( 0 );
 

--- a/src/NetSuiteAccess/Models/ItemsMetaInfo.cs
+++ b/src/NetSuiteAccess/Models/ItemsMetaInfo.cs
@@ -1,0 +1,30 @@
+﻿using Newtonsoft.Json;
+
+namespace NetSuiteAccess.Models
+{
+	public class ItemsMetaInfo
+	{
+		[ JsonProperty( "links" ) ]
+		public Link[] Links { get; set; }
+		[ JsonProperty( "items" ) ]
+		public ItemMetaInfo[] Items { get; set; }
+	}
+
+	public class ItemMetaInfo
+	{
+		[ JsonProperty( "item" ) ]
+		public RecordMetaInfo ItemInfo { get; set; }
+		[ JsonProperty( "description" ) ]
+		public string Description { get; set; }
+		[ JsonProperty( "quantity" ) ]
+		public decimal Quantity { get; set; }
+		[ JsonProperty( "rate" ) ]
+		public decimal Rate { get; set; }
+		[ JsonProperty( "taxRate1" ) ]
+		public decimal TaxRate { get; set; }
+		[ JsonProperty( "vendorName" ) ]
+		public string VendorName { get; set; }
+		[ JsonProperty( "amount" ) ]
+		public decimal Cost { get; set; }
+	}
+}

--- a/src/NetSuiteAccess/Models/Order.cs
+++ b/src/NetSuiteAccess/Models/Order.cs
@@ -1,12 +1,9 @@
-﻿using NetSuiteAccess.Shared;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using System;
-using System.Collections.Generic;
-using System.Globalization;
 
 namespace NetSuiteAccess.Models
 {
-	public class Order
+	public abstract class Order
 	{
 		[ JsonProperty( "id" ) ]
 		public long Id { get; set; }
@@ -19,53 +16,15 @@ namespace NetSuiteAccess.Models
 		public decimal Total { get; set; }
 		[ JsonProperty( "shippingaddress" ) ]
 		public ShippingAddress ShippingAddress { get; set; }
-		[ JsonProperty( "shipMethod" ) ]
-		public RecordMetaInfo ShipMethod { get; set; }
-		[ JsonProperty( "shippingCost" ) ]
-		public decimal ShippingCost { get; set; }
+		[ JsonProperty( "shipDate" ) ]
+		public DateTime ShipDate { get; set; }
 		[ JsonProperty( "email" ) ]
 		public string Email { get; set; }
 		[ JsonProperty( "item" ) ]
 		public ItemsMetaInfo ItemsInfo { get; set; }
 	}
 
-	public class ShippingAddress
-	{
-		[ JsonProperty( "addressee" ) ]
-		public string Addressee { get; set; }
-		[ JsonProperty( "addr1" ) ]
-		public string Addr1 { get; set; }
-		[ JsonProperty( "city" ) ]
-		public string City { get; set; }
-		[ JsonProperty( "country" ) ]
-		public string Country { get; set; }
-		[ JsonProperty( "state" ) ]
-		public string State { get; set; }
-		[ JsonProperty( "zip" ) ]
-		public string Zip { get; set; }
-	}
-
-	public class ItemsMetaInfo
-	{
-		[ JsonProperty( "links" ) ]
-		public Link[] Links { get; set; }
-		[ JsonProperty( "items" ) ]
-		public ItemMetaInfo[] Items { get; set; }
-	}
-
-	public class ItemMetaInfo
-	{
-		[ JsonProperty( "item" ) ]
-		public RecordMetaInfo ItemInfo { get; set; }
-		[ JsonProperty( "quantity" ) ]
-		public decimal Quantity { get; set; }
-		[ JsonProperty( "rate" ) ]
-		public decimal Rate { get; set; }
-		[ JsonProperty( "taxRate1" ) ]
-		public decimal TaxRate { get; set; }
-	}
-
-	public class NetSuiteOrder
+	public abstract class NetSuiteOrder
 	{
 		public long Id { get; set; }
 		public long DocNumber { get; set; }
@@ -74,16 +33,6 @@ namespace NetSuiteAccess.Models
 		public string Status { get; set; }
 		public NetSuiteShippingInfo ShippingInfo { get; set; }
 		public decimal Total { get; set; }
-		public NetSuiteOrderItem[] Items { get; set; }
-	}
-
-	public class NetSuiteOrderItem
-	{
-		public string Sku { get; set; }
-		public int Quantity { get; set; }
-		public decimal UnitPrice { get; set; }
-		public decimal Tax { get; set; }
-		public decimal TaxRate { get; set; }
 	}
 
 	public class NetSuiteShippingInfo
@@ -108,68 +57,5 @@ namespace NetSuiteAccess.Models
 	{
 		public string Name { get; set; }
 		public string Email { get; set; }
-	}
-
-	public static class OrderExtensions
-	{
-		public static NetSuiteOrder ToSvOrder( this Order order )
-		{
-			var svOrder = new NetSuiteOrder
-			{
-				Id = order.Id,
-				DocNumber = order.TranId,
-				CreatedDateUtc = order.CreatedDate.FromRFC3339ToUtc(),
-				ModifiedDateUtc = order.LastModifiedDate.FromRFC3339ToUtc(),
-				Status = order.Status,
-				Total = order.Total
-			};
-
-			svOrder.ShippingInfo = new NetSuiteShippingInfo()
-			{
-				Cost = order.ShippingCost
-			};
-
-			if ( order.ShippingAddress != null )
-			{
-				svOrder.ShippingInfo.Address = new NetSuiteShippingAddress()
-				{
-					Line1 = order.ShippingAddress.Addr1,
-					City = order.ShippingAddress.City,
-					PostalCode = order.ShippingAddress.Zip,
-					CountryCode = order.ShippingAddress.Country,
-					State = order.ShippingAddress.State
-				};
-				svOrder.ShippingInfo.ContactInfo = new NetSuiteShippingContactInfo()
-				{
-					Name = order.ShippingAddress.Addressee,
-					Email = order.Email
-				};
-			}
-
-			if ( order.ShipMethod != null )
-			{
-				svOrder.ShippingInfo.Carrier = order.ShipMethod.RefName;
-			}
-
-			var items = new List< NetSuiteOrderItem >();
-
-			if ( order.ItemsInfo != null )
-			{
-				foreach( var itemInfo in order.ItemsInfo.Items )
-				{
-					items.Add( new NetSuiteOrderItem()
-					{
-						Quantity = (int)Math.Floor( itemInfo.Quantity ),
-						Sku = itemInfo.ItemInfo != null ? itemInfo.ItemInfo.RefName : string.Empty,
-						UnitPrice = itemInfo.Rate,
-						TaxRate = itemInfo.TaxRate,
-						Tax = itemInfo.Rate * (itemInfo.TaxRate / 100)
-					} );
-				}
-			}
-			svOrder.Items = items.ToArray();
-
-			return svOrder;
-		}
 	}
 }

--- a/src/NetSuiteAccess/Models/PurchaseOrder.cs
+++ b/src/NetSuiteAccess/Models/PurchaseOrder.cs
@@ -1,0 +1,80 @@
+﻿using NetSuiteAccess.Shared;
+using System;
+using System.Collections.Generic;
+
+namespace NetSuiteAccess.Models
+{
+	public class PurchaseOrder : Order { }
+
+	public class NetSuitePurchaseOrder : NetSuiteOrder
+	{
+		public string SupplierName { get; set; }
+		public DateTime ShipDate { get; set; }
+		public NetSuitePurchaseOrderItem[] Items { get; set; }
+	}
+
+	public class NetSuitePurchaseOrderItem
+	{
+		public string Sku { get; set; }
+		public string Title { get; set; }
+		public decimal UnitPrice { get; set; }
+		public int Quantity { get; set; }
+	}
+
+	public static class PurchaseOrderExtensions
+	{
+		public static NetSuitePurchaseOrder ToSVPurchaseOrder( this PurchaseOrder order )
+		{
+			var svPurchaseOrder = new NetSuitePurchaseOrder()
+			{
+				Id = order.Id,
+				DocNumber = order.TranId,
+				CreatedDateUtc = order.CreatedDate.FromRFC3339ToUtc(),
+				ModifiedDateUtc = order.LastModifiedDate.FromRFC3339ToUtc(),
+				Status = order.Status,
+				Total = order.Total,
+				ShipDate = order.ShipDate
+			};
+
+			svPurchaseOrder.ShippingInfo = new NetSuiteShippingInfo();
+
+			if ( order.ShippingAddress != null )
+			{
+				svPurchaseOrder.ShippingInfo.Address = new NetSuiteShippingAddress()
+				{
+					Line1 = order.ShippingAddress.Addr1,
+					City = order.ShippingAddress.City,
+					PostalCode = order.ShippingAddress.Zip,
+					CountryCode = order.ShippingAddress.Country,
+					State = order.ShippingAddress.State
+				};
+				svPurchaseOrder.ShippingInfo.ContactInfo = new NetSuiteShippingContactInfo()
+				{
+					Name = order.ShippingAddress.Addressee,
+					Email = order.Email
+				};
+			}
+
+			var items = new List< NetSuitePurchaseOrderItem >();
+
+			if ( order.ItemsInfo != null )
+			{
+				foreach( var itemInfo in order.ItemsInfo.Items )
+				{
+					svPurchaseOrder.SupplierName = itemInfo.VendorName;
+
+					items.Add( new NetSuitePurchaseOrderItem()
+					{
+						Quantity = (int)Math.Floor( itemInfo.Quantity ),
+						Sku = itemInfo.ItemInfo != null ? itemInfo.ItemInfo.RefName : string.Empty,
+						Title = itemInfo.Description,
+						UnitPrice = itemInfo.Rate
+					} );
+				}
+			}
+			svPurchaseOrder.Items = items.ToArray();
+
+			return svPurchaseOrder;
+		}
+	}
+}

--- a/src/NetSuiteAccess/Models/SalesOrder.cs
+++ b/src/NetSuiteAccess/Models/SalesOrder.cs
@@ -1,0 +1,92 @@
+﻿using NetSuiteAccess.Shared;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+
+namespace NetSuiteAccess.Models
+{
+	public class SalesOrder : Order
+	{
+		[ JsonProperty( "shipMethod" ) ]
+		public RecordMetaInfo ShipMethod { get; set; }
+		[ JsonProperty( "shippingCost" ) ]
+		public decimal ShippingCost { get; set; }
+	}
+
+	public class NetSuiteSalesOrder : NetSuiteOrder
+	{
+		public NetSuiteSalesOrderItem[] Items { get; set; }
+	}
+
+	public class NetSuiteSalesOrderItem
+	{
+		public string Sku { get; set; }
+		public int Quantity { get; set; }
+		public decimal UnitPrice { get; set; }
+		public decimal Tax { get; set; }
+		public decimal TaxRate { get; set; }
+	}
+
+	public static class OrderExtensions
+	{
+		public static NetSuiteSalesOrder ToSVSalesOrder( this SalesOrder order )
+		{
+			var svOrder = new NetSuiteSalesOrder
+			{
+				Id = order.Id,
+				DocNumber = order.TranId,
+				CreatedDateUtc = order.CreatedDate.FromRFC3339ToUtc(),
+				ModifiedDateUtc = order.LastModifiedDate.FromRFC3339ToUtc(),
+				Status = order.Status,
+				Total = order.Total
+			};
+
+			svOrder.ShippingInfo = new NetSuiteShippingInfo()
+			{
+				Cost = order.ShippingCost
+			};
+
+			if ( order.ShippingAddress != null )
+			{
+				svOrder.ShippingInfo.Address = new NetSuiteShippingAddress()
+				{
+					Line1 = order.ShippingAddress.Addr1,
+					City = order.ShippingAddress.City,
+					PostalCode = order.ShippingAddress.Zip,
+					CountryCode = order.ShippingAddress.Country,
+					State = order.ShippingAddress.State
+				};
+				svOrder.ShippingInfo.ContactInfo = new NetSuiteShippingContactInfo()
+				{
+					Name = order.ShippingAddress.Addressee,
+					Email = order.Email
+				};
+			}
+
+			if ( order.ShipMethod != null )
+			{
+				svOrder.ShippingInfo.Carrier = order.ShipMethod.RefName;
+			}
+
+			var items = new List< NetSuiteSalesOrderItem >();
+
+			if ( order.ItemsInfo != null )
+			{
+				foreach( var itemInfo in order.ItemsInfo.Items )
+				{
+					items.Add( new NetSuiteSalesOrderItem()
+					{
+						Quantity = (int)Math.Floor( itemInfo.Quantity ),
+						Sku = itemInfo.ItemInfo != null ? itemInfo.ItemInfo.RefName : string.Empty,
+						UnitPrice = itemInfo.Rate,
+						TaxRate = itemInfo.TaxRate,
+						Tax = itemInfo.Rate * (itemInfo.TaxRate / 100)
+					} );
+				}
+			}
+			svOrder.Items = items.ToArray();
+
+			return svOrder;
+		}
+	}
+}

--- a/src/NetSuiteAccess/Models/ShippingAddress.cs
+++ b/src/NetSuiteAccess/Models/ShippingAddress.cs
@@ -1,0 +1,20 @@
+﻿using Newtonsoft.Json;
+
+namespace NetSuiteAccess.Models
+{
+	public class ShippingAddress
+	{
+		[ JsonProperty( "addressee" ) ]
+		public string Addressee { get; set; }
+		[ JsonProperty( "addr1" ) ]
+		public string Addr1 { get; set; }
+		[ JsonProperty( "city" ) ]
+		public string City { get; set; }
+		[ JsonProperty( "country" ) ]
+		public string Country { get; set; }
+		[ JsonProperty( "state" ) ]
+		public string State { get; set; }
+		[ JsonProperty( "zip" ) ]
+		public string Zip { get; set; }
+	}
+}

--- a/src/NetSuiteAccess/NetSuiteAccess.csproj
+++ b/src/NetSuiteAccess/NetSuiteAccess.csproj
@@ -9,10 +9,10 @@
     <PackageLicenseUrl>https://github.com/skuvault/netsuiteAccess/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skuvault/netsuiteAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault/netsuiteAccess</RepositoryUrl>
-    <Version>0.1.0.0-alpha</Version>
+    <Version>0.2.0.0-alpha</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>0.1.0.0</AssemblyVersion>
-    <FileVersion>0.1.0.0</FileVersion>
+    <AssemblyVersion>0.2.0.0</AssemblyVersion>
+    <FileVersion>0.2.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NetSuiteAccess/NetSuiteAccess.csproj
+++ b/src/NetSuiteAccess/NetSuiteAccess.csproj
@@ -9,10 +9,10 @@
     <PackageLicenseUrl>https://github.com/skuvault/netsuiteAccess/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skuvault/netsuiteAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault/netsuiteAccess</RepositoryUrl>
-    <Version>0.2.0.0-alpha</Version>
+    <Version>0.2.1.0-alpha</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>0.2.0.0</AssemblyVersion>
-    <FileVersion>0.2.0.0</FileVersion>
+    <AssemblyVersion>0.2.1.0</AssemblyVersion>
+    <FileVersion>0.2.1.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NetSuiteAccess/Services/BaseService.cs
+++ b/src/NetSuiteAccess/Services/BaseService.cs
@@ -78,6 +78,7 @@ namespace NetSuiteAccess.Services
 
 			var responseContent = await this.ThrottleRequestAsync( command, mark, async ( token ) =>
 			{
+				this.InitSecurityProtocol();
 				this.SetOAuthHeader( command );
 				var httpResponse = await HttpClient.GetAsync( command.Url ).ConfigureAwait( false );
 				var content = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait( false );
@@ -155,6 +156,11 @@ namespace NetSuiteAccess.Services
 					() => CreateMethodCallInfo( command.Url, mark, additionalInfo: this.AdditionalLogInfo() ),
 					NetSuiteLogger.LogTraceException );
 			} );
+		}
+
+		private void InitSecurityProtocol()
+		{
+			ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12 | SecurityProtocolType.Ssl3;
 		}
 
 		private string CreateMethodCallInfo( string url = "", Mark mark = null, string errors = "", string methodResult = "", string additionalInfo = "", string payload = "", [ CallerMemberName ] string memberName = "" )

--- a/src/NetSuiteAccess/Services/Orders/INetSuiteOrdersService.cs
+++ b/src/NetSuiteAccess/Services/Orders/INetSuiteOrdersService.cs
@@ -8,6 +8,7 @@ namespace NetSuiteAccess.Services.Orders
 {
 	public interface INetSuiteOrdersService
 	{
-		Task< IEnumerable< NetSuiteOrder > > GetOrdersAsync( DateTime startDateUtc, DateTime endDateUtc, CancellationToken token );
+		Task< IEnumerable< NetSuiteSalesOrder > > GetSalesOrdersAsync( DateTime startDateUtc, DateTime endDateUtc, CancellationToken token );
+		Task< IEnumerable< NetSuitePurchaseOrder > > GetPurchaseOrdersAsync( DateTime startDateUtc, DateTime endDateUtc, CancellationToken token );
 	}
 }

--- a/src/NetSuiteAccess/Services/Orders/NetSuiteOrdersService.cs
+++ b/src/NetSuiteAccess/Services/Orders/NetSuiteOrdersService.cs
@@ -14,16 +14,31 @@ namespace NetSuiteAccess.Services.Orders
 		{
 		}
 
-		public async Task< IEnumerable< NetSuiteOrder > > GetOrdersAsync( DateTime startDateUtc, DateTime endDateUtc, CancellationToken token )
+		public async Task< IEnumerable< NetSuitePurchaseOrder > > GetPurchaseOrdersAsync( DateTime startDateUtc, DateTime endDateUtc, CancellationToken token )
 		{
-			var orders = new List< NetSuiteOrder >();
+			var purchaseOrders = new List< NetSuitePurchaseOrder >();
+			var command = new GetModifiedPurchaseOrdersCommand( base.Config, startDateUtc, endDateUtc );
+			var ordersIds = await base.GetEntitiesIds( command, Config.OrdersPageSize, token ).ConfigureAwait( false );
+
+			foreach( var orderId in ordersIds )
+			{
+				var purchaseOrder = await base.GetAsync< PurchaseOrder >( new GetPurchaseOrderCommand( this.Config, orderId ), token ).ConfigureAwait( false );
+				purchaseOrders.Add( purchaseOrder.ToSVPurchaseOrder() );
+			}
+
+			return purchaseOrders.ToArray();
+		}
+
+		public async Task< IEnumerable< NetSuiteSalesOrder > > GetSalesOrdersAsync( DateTime startDateUtc, DateTime endDateUtc, CancellationToken token )
+		{
+			var orders = new List< NetSuiteSalesOrder >();
 			var command = new GetModifiedSalesOrdersCommand( base.Config, startDateUtc, endDateUtc );
 			var ordersIds = await base.GetEntitiesIds( command, Config.OrdersPageSize, token ).ConfigureAwait( false );
 
 			foreach( var orderId in ordersIds )
 			{
-				var order = await base.GetAsync< Order >( new GetOrderCommand( this.Config, orderId ), token ).ConfigureAwait( false );
-				orders.Add( order.ToSvOrder() );
+				var order = await base.GetAsync< SalesOrder >( new GetSalesOrderCommand( this.Config, orderId ), token ).ConfigureAwait( false );
+				orders.Add( order.ToSVSalesOrder() );
 			}
 
 			return orders.ToArray();

--- a/src/NetSuiteTests/OrderMapperTests.cs
+++ b/src/NetSuiteTests/OrderMapperTests.cs
@@ -14,9 +14,9 @@ namespace NetSuiteTests
 	public class OrderMapperTests
 	{
 		[ Test ]
-		public void ToSVOrder()
+		public void ToSVSalesOrder()
 		{
-			var order = new Order()
+			var order = new SalesOrder()
 			{
 				Id = 1,
 				CreatedDate = "2019-11-29T10:00:00Z",
@@ -49,13 +49,15 @@ namespace NetSuiteTests
 							{
 								Id = 1050,
 								RefName = "product555"
-							}
+							},
+							TaxRate = 10,
+							Rate = 15
 						}
 					}
 				}
 			};
 
-			var result = order.ToSvOrder();
+			var result = order.ToSVSalesOrder();
 			result.Should().NotBeNull();
 			result.Id.Should().Be( order.Id );
 			result.CreatedDateUtc.Should().Be( order.CreatedDate.FromRFC3339ToUtc() );
@@ -78,6 +80,72 @@ namespace NetSuiteTests
 			result.Items.Count().Should().Be( 1 );
 			result.Items[0].Quantity.Should().Be( (int)order.ItemsInfo.Items[0].Quantity );
 			result.Items[0].Sku.Should().Be( order.ItemsInfo.Items[0].ItemInfo.RefName );
+			result.Items[0].UnitPrice.Should().Be( order.ItemsInfo.Items[0].Rate );
+			result.Items[0].TaxRate.Should().Be( order.ItemsInfo.Items[0].TaxRate );
+			result.Items[0].Tax.Should().Be( order.ItemsInfo.Items[0].TaxRate / 100 * order.ItemsInfo.Items[0].Rate );
+		}
+
+		[ Test ]
+		public void ToSVPurchaseOrder()
+		{
+			var order = new PurchaseOrder()
+			{
+				Id = 1,
+				CreatedDate = "2019-11-29T10:00:00Z",
+				LastModifiedDate = "2019-11-29T10:00:00Z",
+				Status = "Pending Receipt",
+				Total = 10,
+				ShippingAddress = new ShippingAddress()
+				{
+					Addr1 = "123 Bing Bong Lane",
+					Addressee = "SkuVault",
+					City = "Lousiville",
+					Country = "US",
+					State = "KY",
+					Zip = "40206"
+				},
+				ShipDate = new DateTime( 2019, 12, 6 ),
+				ItemsInfo = new ItemsMetaInfo()
+				{
+					Items = new ItemMetaInfo[]
+					{
+						new ItemMetaInfo()
+						{
+							Quantity = 10,
+							ItemInfo = new RecordMetaInfo()
+							{
+								Id = 1050,
+								RefName = "product555"
+							},
+							Description = "Test product",
+							Rate = 5
+						}
+					}
+				}
+			};
+
+			var result = order.ToSVPurchaseOrder();
+			result.Should().NotBeNull();
+			result.Id.Should().Be( order.Id );
+			result.CreatedDateUtc.Should().Be( order.CreatedDate.FromRFC3339ToUtc() );
+			result.ModifiedDateUtc.Should().Be( order.LastModifiedDate.FromRFC3339ToUtc() );
+			result.Status.Should().Be( order.Status );
+			
+			result.ShippingInfo.ContactInfo.Should().NotBeNull();
+			result.ShippingInfo.ContactInfo.Name.Should().Be( order.ShippingAddress.Addressee );
+
+			result.ShippingInfo.Address.Should().NotBeNull();
+			result.ShippingInfo.Address.Line1.Should().Be( order.ShippingAddress.Addr1 );
+			result.ShippingInfo.Address.CountryCode.Should().Be( order.ShippingAddress.Country );
+			result.ShippingInfo.Address.City.Should().Be( order.ShippingAddress.City );
+			result.ShippingInfo.Address.PostalCode.Should().Be( order.ShippingAddress.Zip );
+			result.ShipDate.Should().Be( order.ShipDate );
+			
+			result.Items.Count().Should().Be( 1 );
+			result.Items[0].Quantity.Should().Be( (int)order.ItemsInfo.Items[0].Quantity );
+			result.Items[0].Sku.Should().Be( order.ItemsInfo.Items[0].ItemInfo.RefName );
+			result.Items[0].Title.Should().Be( order.ItemsInfo.Items[0].Description );
+			result.Items[0].UnitPrice.Should().Be( order.ItemsInfo.Items[0].Rate );
 		}
 	}
 }

--- a/src/NetSuiteTests/OrderTests.cs
+++ b/src/NetSuiteTests/OrderTests.cs
@@ -20,18 +20,33 @@ namespace NetSuiteTests
 		}
 
 		[ Test ]
-		public void GetModifiedOrders()
+		public void GetModifiedSalesOrders()
 		{
-			var orders = this._ordersService.GetOrdersAsync( DateTime.UtcNow.AddMonths( -1 ), DateTime.UtcNow, CancellationToken.None ).Result;
-			orders.Count().Should().BeGreaterThan( 0 );
+			var salesOrders = this._ordersService.GetSalesOrdersAsync( DateTime.UtcNow.AddMonths( -1 ), DateTime.UtcNow, CancellationToken.None ).Result;
+			salesOrders.Count().Should().BeGreaterThan( 0 );
 		}
 
 		[ Test ]
-		public void GetModifiedOrdersByPage()
+		public void GetModifiedSalesOrdersByPage()
 		{
 			Config.OrdersPageSize = 1;
-			var orders = this._ordersService.GetOrdersAsync( DateTime.UtcNow.AddMonths( -1 ), DateTime.UtcNow, CancellationToken.None ).Result;
-			orders.Count().Should().BeGreaterThan( 0 );
+			var salesOrders = this._ordersService.GetSalesOrdersAsync( DateTime.UtcNow.AddMonths( -1 ), DateTime.UtcNow, CancellationToken.None ).Result;
+			salesOrders.Count().Should().BeGreaterThan( 0 );
+		}
+
+		[ Test ]
+		public void GetModifiedPurchaseOrders()
+		{
+			var purchaseOrders = this._ordersService.GetPurchaseOrdersAsync( DateTime.UtcNow.AddMonths( -1 ), DateTime.UtcNow, CancellationToken.None ).Result;
+			purchaseOrders.Count().Should().BeGreaterThan( 0 );
+		}
+
+		[ Test ]
+		public void GetModifiedPurchaseOrdersByPage()
+		{
+			Config.OrdersPageSize = 1;
+			var purchaseOrders = this._ordersService.GetPurchaseOrdersAsync( DateTime.UtcNow.AddMonths( -1 ), DateTime.UtcNow, CancellationToken.None ).Result;
+			purchaseOrders.Count().Should().BeGreaterThan( 0 );
 		}
 	}
 }


### PR DESCRIPTION
Summary
- implemented pulling purchase orders;
- refactored code: renamed Orders to SalesOrder, made common ancestor to purchase and sales order.