### PR TITLE
2019-12-11 GUARD-254 Purchase-Order-Empty-Supplier-Name

### DIFF
--- a/src/NetSuiteAccess/Models/ItemsMetaInfo.cs
+++ b/src/NetSuiteAccess/Models/ItemsMetaInfo.cs
@@ -22,8 +22,6 @@ namespace NetSuiteAccess.Models
 		public decimal Rate { get; set; }
 		[ JsonProperty( "taxRate1" ) ]
 		public decimal TaxRate { get; set; }
-		[ JsonProperty( "vendorName" ) ]
-		public string VendorName { get; set; }
 		[ JsonProperty( "amount" ) ]
 		public decimal Cost { get; set; }
 	}

--- a/src/NetSuiteAccess/Models/PurchaseOrder.cs
+++ b/src/NetSuiteAccess/Models/PurchaseOrder.cs
@@ -50,14 +50,17 @@ namespace NetSuiteAccess.Models
 				};
 			}
 
+			if ( order.Entity != null )
+			{
+				svPurchaseOrder.SupplierName = order.Entity.RefName;
+			}
+
 			var items = new List< NetSuitePurchaseOrderItem >();
 
 			if ( order.ItemsInfo != null )
 			{
 				foreach( var itemInfo in order.ItemsInfo.Items )
 				{
-					svPurchaseOrder.SupplierName = itemInfo.VendorName;
-
 					items.Add( new NetSuitePurchaseOrderItem()
 					{
 						Quantity = (int)Math.Floor( itemInfo.Quantity ),

--- a/src/NetSuiteAccess/NetSuiteAccess.csproj
+++ b/src/NetSuiteAccess/NetSuiteAccess.csproj
@@ -9,10 +9,10 @@
     <PackageLicenseUrl>https://github.com/skuvault/netsuiteAccess/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skuvault/netsuiteAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault/netsuiteAccess</RepositoryUrl>
-    <Version>0.2.2.0-alpha</Version>
+    <Version>0.2.3.0-alpha</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>0.2.2.0</AssemblyVersion>
-    <FileVersion>0.2.2.0</FileVersion>
+    <AssemblyVersion>0.2.3.0</AssemblyVersion>
+    <FileVersion>0.2.3.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NetSuiteTests/OrderMapperTests.cs
+++ b/src/NetSuiteTests/OrderMapperTests.cs
@@ -125,6 +125,11 @@ namespace NetSuiteTests
 							Rate = 5
 						}
 					}
+				},
+				Entity = new RecordMetaInfo()
+				{
+					Id = 1,
+					RefName = "Samsung"
 				}
 			};
 
@@ -141,6 +146,8 @@ namespace NetSuiteTests
 			result.ShippingInfo.Address.City.Should().Be( order.ShippingAddress.City );
 			result.ShippingInfo.Address.PostalCode.Should().Be( order.ShippingAddress.Zip );
 			result.ShipDate.Should().Be( order.ShipDate );
+
+			result.SupplierName.Should().Be( order.Entity.RefName );
 			
 			result.Items.Count().Should().Be( 1 );
 			result.Items[0].Quantity.Should().Be( (int)order.ItemsInfo.Items[0].Quantity );


### PR DESCRIPTION
Summary
Supplier name should be pulled from purchase order's entity field.