### PR TITLE
2019-12-25 GUARD-340 Products-Sync

### DIFF
--- a/src/NetSuiteAccess/Models/Item.cs
+++ b/src/NetSuiteAccess/Models/Item.cs
@@ -1,0 +1,40 @@
+﻿using NetSuiteSoapWS;
+
+namespace NetSuiteAccess.Models
+{
+	public class NetSuiteItem
+	{
+		public string Name { get; set; }
+		public string Sku { get; set; }
+		public string CategoryName { get; set; }
+		public double? Weight { get; set; }
+		public string WeightUnit { get; set; }
+		public double? Price { get; set; }
+		public string MPN { get; set; }
+		public string Manufacturer { get; set; }
+	}
+
+	public static class ItemExtensions
+	{
+		public static NetSuiteItem ToSVItem( this InventoryItem item )
+		{
+			var svItem = new NetSuiteItem()
+			{
+				Name = item.displayName,
+				Sku = item.itemId,
+				Weight = item.weight,
+				WeightUnit = item.weightUnit.ToString(),	
+				Manufacturer = item.manufacturer,
+				Price = item.cost,
+				MPN = item.mpn
+			};
+
+			if ( item.@class != null )
+			{
+				svItem.CategoryName = item.@class.name;
+			}
+
+			return svItem;
+		}
+	}
+}

--- a/src/NetSuiteAccess/NetSuiteAccess.csproj
+++ b/src/NetSuiteAccess/NetSuiteAccess.csproj
@@ -9,10 +9,10 @@
     <PackageLicenseUrl>https://github.com/skuvault/netsuiteAccess/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skuvault/netsuiteAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault/netsuiteAccess</RepositoryUrl>
-    <Version>0.3.3.0-alpha</Version>
+    <Version>0.4.0.0-rc1</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>0.3.3.0</AssemblyVersion>
-    <FileVersion>0.3.3.0</FileVersion>
+    <AssemblyVersion>0.4.0.0</AssemblyVersion>
+    <FileVersion>0.4.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NetSuiteAccess/Services/Items/INetSuiteItemsService.cs
+++ b/src/NetSuiteAccess/Services/Items/INetSuiteItemsService.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using NetSuiteAccess.Models;
+using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -9,5 +11,6 @@ namespace NetSuiteAccess.Services.Items
 		Task UpdateItemQuantityBySkuAsync( int accountId, string warehouseName, string sku, int quantity, CancellationToken token );
 		Task UpdateSkusQuantitiesAsync( int accountId, string warehouseName, Dictionary< string, int > skuQuantities, CancellationToken token );
 		Task< int > GetSkuQuantity( string sku, string warehouse, CancellationToken token );
+		Task< IEnumerable< NetSuiteItem > > GetItemsCreatedUpdatedAfterAsync( DateTime startDateUtc, bool includeUpdated, CancellationToken token );
 	}
 }

--- a/src/NetSuiteTests/ItemMapperTests.cs
+++ b/src/NetSuiteTests/ItemMapperTests.cs
@@ -1,0 +1,36 @@
+﻿using FluentAssertions;
+using NetSuiteAccess.Models;
+using NetSuiteSoapWS;
+using NUnit.Framework;
+
+namespace NetSuiteTests
+{
+	[ TestFixture ]
+	public class ItemMapperTests
+	{
+		[ Test ]
+		public void ToSVItem()
+		{
+			var item = new InventoryItem()
+			{
+				itemId = "NS-testsku1",
+				displayName = "NS-testsku1",
+				weight = 10.0,
+				weightUnit = ItemWeightUnit._lb,
+				manufacturer = "Samsung",
+				cost = 15.0,
+				mpn = "7209101"
+			};
+
+			var svItem = item.ToSVItem();
+
+			svItem.Name.Should().Be( item.displayName );
+			svItem.Sku.Should().Be( item.itemId );
+			svItem.Weight.Should().Be( item.weight );
+			svItem.WeightUnit.Should().Be( item.weightUnit.ToString() );
+			svItem.Manufacturer.Should().Be( item.manufacturer );
+			svItem.Price.Should().Be( item.cost );
+			svItem.MPN.Should().Be( item.mpn );
+		}
+	}
+}

--- a/src/NetSuiteTests/ItemTests.cs
+++ b/src/NetSuiteTests/ItemTests.cs
@@ -3,6 +3,7 @@ using NetSuiteAccess.Services.Items;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -73,6 +74,22 @@ namespace NetSuiteTests
 				catch( NetSuiteItemNotFoundException )
 				{ }
 			}
+		}
+
+		[ Test ]
+		public void GetInventoryItemsCreatedAfterSpecifiedDate()
+		{
+			var createdDate = new DateTime( 2019, 12, 1 );
+			var newItems = this._itemsService.GetItemsCreatedUpdatedAfterAsync( createdDate, false, CancellationToken.None ).Result;
+			newItems.Count().Should().BeGreaterThan( 0 );
+		}
+
+		[ Test ]
+		public void GetInventoryItemsCreatedAndModifiedAfterSpecificDate()
+		{
+			var createOrModifiedDate = new DateTime( 2019, 12, 1 );
+			var items = this._itemsService.GetItemsCreatedUpdatedAfterAsync( createOrModifiedDate, true, CancellationToken.None ).Result;
+			items.Count().Should().BeGreaterThan( 0 );
 		}
 	}
 }

--- a/src/NetSuiteTests/NetSuiteTests.csproj
+++ b/src/NetSuiteTests/NetSuiteTests.csproj
@@ -71,6 +71,7 @@
     <Compile Include="BaseTest.cs" />
     <Compile Include="CommonTests.cs" />
     <Compile Include="CustomerTests.cs" />
+    <Compile Include="ItemMapperTests.cs" />
     <Compile Include="ItemTests.cs" />
     <Compile Include="OrderMapperTests.cs" />
     <Compile Include="OrderTests.cs" />


### PR DESCRIPTION
Implemented two methods for products sync:
- lists items created after specified date;
- lists items changed after specified date.

I found out that we can't extract some fields from inventory item that we usually pull in the other product sync integrations:
- sale price, regular price (price matrix property is always null although UI shows data);
- item image (store display image is null).