### PR TITLE
2020-05-18 GUARD-584 Warehouse-Not-Found-Error

### DIFF
--- a/src/NetSuiteAccess/NetSuiteAccess.csproj
+++ b/src/NetSuiteAccess/NetSuiteAccess.csproj
@@ -9,10 +9,10 @@
     <PackageLicenseUrl>https://github.com/skuvault/netsuiteAccess/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skuvault/netsuiteAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault/netsuiteAccess</RepositoryUrl>
-    <Version>1.2.5.0</Version>
+    <Version>1.2.6.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.2.5.0</AssemblyVersion>
-    <FileVersion>1.2.5.0</FileVersion>
+    <AssemblyVersion>1.2.6.0</AssemblyVersion>
+    <FileVersion>1.2.6.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NetSuiteAccess/NetSuiteAccess.csproj
+++ b/src/NetSuiteAccess/NetSuiteAccess.csproj
@@ -9,10 +9,10 @@
     <PackageLicenseUrl>https://github.com/skuvault/netsuiteAccess/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skuvault/netsuiteAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault/netsuiteAccess</RepositoryUrl>
-    <Version>1.2.6.0</Version>
+    <Version>1.2.7.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.2.6.0</AssemblyVersion>
-    <FileVersion>1.2.6.0</FileVersion>
+    <AssemblyVersion>1.2.7.0</AssemblyVersion>
+    <FileVersion>1.2.7.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NetSuiteAccess/Services/Common/INetSuiteCommonService.cs
+++ b/src/NetSuiteAccess/Services/Common/INetSuiteCommonService.cs
@@ -9,5 +9,6 @@ namespace NetSuiteAccess.Services.Common
 	{
 		Task< IEnumerable< NetSuiteLocation > > GetLocationsAsync( CancellationToken token );
 		Task< IEnumerable< NetSuiteAccount > > GetAccountsAsync( CancellationToken token );
+		Task< NetSuiteLocation > GetLocationByNameAsync( string locationName, CancellationToken token );
 	}
 }

--- a/src/NetSuiteAccess/Services/Common/NetSuiteCommonService.cs
+++ b/src/NetSuiteAccess/Services/Common/NetSuiteCommonService.cs
@@ -32,5 +32,10 @@ namespace NetSuiteAccess.Services.Common
 		{
 			return _soapService.ListLocationsAsync( token );
 		}
+
+		public Task< NetSuiteLocation > GetLocationByNameAsync( string locationName, CancellationToken token )
+		{
+			return _soapService.GetLocationByNameAsync( locationName, token );
+		}
 	}
 }

--- a/src/NetSuiteAccess/Services/Items/NetSuiteItemsService.cs
+++ b/src/NetSuiteAccess/Services/Items/NetSuiteItemsService.cs
@@ -110,7 +110,7 @@ namespace NetSuiteAccess.Services.Items
 				if ( itemInventory == null )
 					continue;
 
-				var warehouseInventory = itemInventory.Where( i => i.locationId.name.ToLower().Equals( warehouseName.ToLower() ) ).FirstOrDefault();
+				var warehouseInventory = itemInventory.Where( i => i.locationId.internalId.Equals( warehouseInfo.Id.ToString() ) ).FirstOrDefault();
 
 				if ( warehouseInventory == null )
 					continue;

--- a/src/NetSuiteAccess/Services/Soap/NetSuiteSoapService.cs
+++ b/src/NetSuiteAccess/Services/Soap/NetSuiteSoapService.cs
@@ -327,13 +327,14 @@ namespace NetSuiteAccess.Services.Soap
 					{
 						searchValue = locationName,
 						operatorSpecified = true,
-						@operator = SearchStringFieldOperator.@is
+						@operator = SearchStringFieldOperator.contains
 					}
 				}
 			};
 
 			var response = await this.SearchRecords( locationsSearch, mark, cancellationToken ).ConfigureAwait( false );
-			return response.OfType< Location >().Select( l => l.ToSVLocation() ).FirstOrDefault();
+			return response.OfType< Location >().Where( l => l.name.Equals( locationName ) )
+									.Select( l => l.ToSVLocation() ).FirstOrDefault();
 		}
 
 		/// <summary>

--- a/src/NetSuiteTests/CommonTests.cs
+++ b/src/NetSuiteTests/CommonTests.cs
@@ -26,6 +26,14 @@ namespace NetSuiteTests
 		}
 
 		[ Test ]
+		public async Task GetLocationsByNameAsync()
+		{
+			var locationName = "San Francisco";
+			var location = await this._commonService.GetLocationByNameAsync( locationName, CancellationToken.None );
+			location.Should().NotBeNull();
+		}
+
+		[ Test ]
 		public async Task GetAccountsAsync()
 		{
 			var accounts = await this._commonService.GetAccountsAsync( CancellationToken.None );


### PR DESCRIPTION
Summary
I found out that SOAP location search by name expression with operator @is doesn't work as it should. It doesn't return location although customer's NetSuite contains location with this name. As workaround I've changed operator @is to contains. This issue is not reproducible in our NetSuite sandbox account.

Besides this response with inventory information can contain warehouse name as name and subsidiary ( < subsidiary name > : < warehouse name > ). Match should be performed only by internal id.