### PR TITLE
GUARD-699 Fetch 100 records per batch/page

### DIFF
--- a/src/NetSuiteAccess/Configuration/NetSuiteConfig.cs
+++ b/src/NetSuiteAccess/Configuration/NetSuiteConfig.cs
@@ -11,8 +11,7 @@ namespace NetSuiteAccess.Configuration
 		public readonly ThrottlingOptions ThrottlingOptions;
 		public readonly NetworkOptions NetworkOptions;
 
-		public int OrdersPageSize { get; set; }
-		public int LocationsPageSize { get; set; }
+		public int SearchRecordsPageSize { get; set; }
 
 		public NetSuiteConfig( NetSuiteCredentials credentials, ThrottlingOptions throttlingOptions, NetworkOptions networkOptions )
 		{
@@ -24,8 +23,7 @@ namespace NetSuiteAccess.Configuration
 			this.ThrottlingOptions = throttlingOptions;
 			this.NetworkOptions = networkOptions;
 			this.ApiBaseUrl = string.Format( "https://{0}.suitetalk.api.netsuite.com", credentials.CustomerId );
-			this.OrdersPageSize = 1000;
-			this.LocationsPageSize = 100;
+			this.SearchRecordsPageSize = 100;
 		}
 
 		public NetSuiteConfig( NetSuiteCredentials credentials ) : this( credentials, ThrottlingOptions.NetSuiteDefaultThrottlingOptions, NetworkOptions.NetSuiteDefaultNetworkOptions )

--- a/src/NetSuiteAccess/Configuration/NetSuiteConfig.cs
+++ b/src/NetSuiteAccess/Configuration/NetSuiteConfig.cs
@@ -12,6 +12,7 @@ namespace NetSuiteAccess.Configuration
 		public readonly NetworkOptions NetworkOptions;
 
 		public int SearchRecordsPageSize { get; set; }
+		public static int GetCustomersByIdsPageSize = 100;
 
 		public NetSuiteConfig( NetSuiteCredentials credentials, ThrottlingOptions throttlingOptions, NetworkOptions networkOptions )
 		{

--- a/src/NetSuiteAccess/NetSuiteAccess.csproj
+++ b/src/NetSuiteAccess/NetSuiteAccess.csproj
@@ -9,10 +9,10 @@
     <PackageLicenseUrl>https://github.com/skuvault/netsuiteAccess/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skuvault/netsuiteAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault/netsuiteAccess</RepositoryUrl>
-    <Version>1.6.0.0-alpha</Version>
+    <Version>1.6.2.0-alpha</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.6.0.0</AssemblyVersion>
-    <FileVersion>1.6.0.0</FileVersion>
+    <AssemblyVersion>1.6.2.0</AssemblyVersion>
+    <FileVersion>1.6.2.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NetSuiteAccess/NetSuiteAccess.csproj
+++ b/src/NetSuiteAccess/NetSuiteAccess.csproj
@@ -9,7 +9,7 @@
     <PackageLicenseUrl>https://github.com/skuvault/netsuiteAccess/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skuvault/netsuiteAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault/netsuiteAccess</RepositoryUrl>
-    <Version>1.6.3.0-alpha</Version>
+    <Version>1.6.3.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <AssemblyVersion>1.6.3.0</AssemblyVersion>
     <FileVersion>1.6.3.0</FileVersion>

--- a/src/NetSuiteAccess/NetSuiteAccess.csproj
+++ b/src/NetSuiteAccess/NetSuiteAccess.csproj
@@ -9,10 +9,10 @@
     <PackageLicenseUrl>https://github.com/skuvault/netsuiteAccess/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skuvault/netsuiteAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault/netsuiteAccess</RepositoryUrl>
-    <Version>1.5.0.0</Version>
+    <Version>1.6.0.0-alpha</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.5.0.0</AssemblyVersion>
-    <FileVersion>1.5.0.0</FileVersion>
+    <AssemblyVersion>1.6.0.0</AssemblyVersion>
+    <FileVersion>1.6.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NetSuiteAccess/NetSuiteAccess.csproj
+++ b/src/NetSuiteAccess/NetSuiteAccess.csproj
@@ -9,10 +9,10 @@
     <PackageLicenseUrl>https://github.com/skuvault/netsuiteAccess/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skuvault/netsuiteAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault/netsuiteAccess</RepositoryUrl>
-    <Version>1.6.2.0-alpha</Version>
+    <Version>1.6.3.0-alpha</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.6.2.0</AssemblyVersion>
-    <FileVersion>1.6.2.0</FileVersion>
+    <AssemblyVersion>1.6.3.0</AssemblyVersion>
+    <FileVersion>1.6.3.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NetSuiteAccess/Services/Customers/NetSuiteCustomersService.cs
+++ b/src/NetSuiteAccess/Services/Customers/NetSuiteCustomersService.cs
@@ -4,8 +4,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using NetSuiteAccess.Configuration;
 using NetSuiteAccess.Models;
-using NetSuiteAccess.Models.Commands;
 using NetSuiteAccess.Services.Soap;
+using NetSuiteAccess.Shared;
+using NetSuiteSoapWS;
 
 namespace NetSuiteAccess.Services.Customers
 {
@@ -27,7 +28,7 @@ namespace NetSuiteAccess.Services.Customers
 
 		public async Task< NetSuiteCustomer > GetCustomerInfoByIdAsync( string customerId, CancellationToken token )
 		{
-			var customers = await this.GetCustomersInfoByIdsAsync( new string[] { customerId }, token ).ConfigureAwait( false );
+			var customers = await this.GetCustomersInfoByIdsAsync( new [] { customerId }, token ).ConfigureAwait( false );
 
 			return customers?.FirstOrDefault();
 		}
@@ -41,14 +42,14 @@ namespace NetSuiteAccess.Services.Customers
 		/// <returns></returns>
 		public async Task< IEnumerable< NetSuiteCustomer > > GetCustomersInfoByIdsAsync( string[] customersIds, CancellationToken token )
 		{
-			var customers = await _soapService.GetCustomersByIdsAsync( customersIds, token ).ConfigureAwait( false );
-
-			if ( customers != null && customers.Any() )
+			var customers = new List< Customer >();
+			var customerIdsBatches = customersIds.SplitToPieces( NetSuiteConfig.GetCustomersByIdsPageSize );
+			foreach ( var customerIdsBatch in customerIdsBatches )
 			{
-				return customers.Select( c => c.ToSVCustomer() );
+				customers.AddRange( await _soapService.GetCustomersByIdsAsync( customerIdsBatch, token ).ConfigureAwait( false ) );
 			}
-			
-			return null;
+
+			return customers.Any() ? customers.Select( c => c.ToSVCustomer() ) : null;
 		}
 	}
 }

--- a/src/NetSuiteAccess/Services/Customers/NetSuiteCustomersService.cs
+++ b/src/NetSuiteAccess/Services/Customers/NetSuiteCustomersService.cs
@@ -49,7 +49,7 @@ namespace NetSuiteAccess.Services.Customers
 				customers.AddRange( await _soapService.GetCustomersByIdsAsync( customerIdsBatch, token ).ConfigureAwait( false ) );
 			}
 
-			return customers.Any() ? customers.Select( c => c.ToSVCustomer() ) : null;
+			return customers.Select( c => c.ToSVCustomer() );
 		}
 	}
 }

--- a/src/NetSuiteAccess/Services/Orders/NetSuiteOrdersService.cs
+++ b/src/NetSuiteAccess/Services/Orders/NetSuiteOrdersService.cs
@@ -89,7 +89,7 @@ namespace NetSuiteAccess.Services.Orders
 		public async Task< IEnumerable< NetSuiteSalesOrder > > GetSalesOrdersAsync( DateTime startDateUtc, DateTime endDateUtc, CancellationToken token )
 		{
 			var modifiedOrders = ( await _soapService.GetModifiedSalesOrdersAsync( startDateUtc, endDateUtc, token ).ConfigureAwait( false ) ).ToArray();
-			var customers = await this._customersService.GetCustomersInfoByIdsAsync( modifiedOrders.Select( c => c.Customer.Id.ToString() ).Distinct().ToArray(), token ).ConfigureAwait( false );
+			var customers = ( await this._customersService.GetCustomersInfoByIdsAsync( modifiedOrders.Select( c => c.Customer.Id.ToString() ).Distinct().ToArray(), token ).ConfigureAwait( false ) ).ToList();
 			foreach( var order in modifiedOrders )
 			{
 				order.Customer = customers.FirstOrDefault( c => c.Id == order.Customer.Id );

--- a/src/NetSuiteAccess/Services/Soap/NetSuiteSoapService.cs
+++ b/src/NetSuiteAccess/Services/Soap/NetSuiteSoapService.cs
@@ -869,9 +869,11 @@ namespace NetSuiteAccess.Services.Soap
 			var result = new List< Record >();
 			var response = await this.ThrottleRequestAsync( mark, ( token ) =>
 			{
-				var searchPreferences = new SearchPreferences()
+				var searchPreferences = new SearchPreferences
 				{
-					bodyFieldsOnly = false
+					bodyFieldsOnly = false,
+					pageSize = _config.SearchRecordsPageSize,
+					pageSizeSpecified = true
 				};
 
 				return this._service.searchAsync( null, this._passport, null, null, searchPreferences, searchRecord );

--- a/src/NetSuiteAccess/Shared/IEnumerableExtensions.cs
+++ b/src/NetSuiteAccess/Shared/IEnumerableExtensions.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace NetSuiteAccess.Shared
+{
+	public static class IEnumerableExtensions
+	{
+		public static IEnumerable< IEnumerable< TSource > > SplitToPieces< TSource >( this IEnumerable< TSource > source, int pieceSize )
+		{
+			var res = new List< IEnumerable< TSource > >();
+			var sourceArray = source as TSource[] ?? source.ToArray();
+			for( var c = 0; c < sourceArray.Count(); c += pieceSize )
+			{
+				res.Add( sourceArray.Skip( c ).Take( pieceSize ) );
+			}
+
+			return res;
+		}
+	}
+}

--- a/src/NetSuiteTests/CustomerTests.cs
+++ b/src/NetSuiteTests/CustomerTests.cs
@@ -1,7 +1,9 @@
-﻿using FluentAssertions;
+﻿using System;
+using FluentAssertions;
 using NetSuiteAccess.Services.Customers;
 using NUnit.Framework;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace NetSuiteTests
 {
@@ -41,6 +43,22 @@ namespace NetSuiteTests
 			customerInfo.LastName.Should().BeNullOrWhiteSpace();
 			customerInfo.Phone.Should().NotBeNullOrWhiteSpace();
 			customerInfo.Email.Should().NotBeNullOrWhiteSpace();
+		}
+
+		[ Test ]
+		//Slow, ~1 minute
+		public async Task GetCustomersInfoByIdsAsync_HandlesBatchOfOver1000()
+		{
+			var customersIds = new string[ 1005 ];
+			var random = new Random( DateTime.Now.Millisecond );
+			for ( var i = 0; i < 1005; i++)
+			{
+				customersIds[ i ] = random.Next( 1000 ).ToString();
+			}
+
+			var result = await this._customersService.GetCustomersInfoByIdsAsync( customersIds, CancellationToken.None );
+
+			result.Should().NotBeNull();
 		}
 	}
 }

--- a/src/NetSuiteTests/OrderTests.cs
+++ b/src/NetSuiteTests/OrderTests.cs
@@ -34,7 +34,7 @@ namespace NetSuiteTests
 		[ Test ]
 		public void GetModifiedSalesOrdersByPage()
 		{
-			Config.OrdersPageSize = 1;
+			Config.SearchRecordsPageSize = 5;
 			var salesOrders = this._ordersService.GetSalesOrdersAsync( DateTime.UtcNow.AddMonths( -1 ), DateTime.UtcNow, CancellationToken.None ).Result;
 			salesOrders.Count().Should().BeGreaterThan( 0 );
 		}
@@ -49,7 +49,7 @@ namespace NetSuiteTests
 		[ Test ]
 		public void GetModifiedPurchaseOrdersByPage()
 		{
-			Config.OrdersPageSize = 1;
+			Config.SearchRecordsPageSize = 5;
 			var purchaseOrders = this._ordersService.GetPurchaseOrdersAsync( DateTime.UtcNow.AddMonths( -1 ), DateTime.UtcNow, CancellationToken.None ).Result;
 			purchaseOrders.Count().Should().BeGreaterThan( 0 );
 		}


### PR DESCRIPTION
- Search requests getting NetSuite orders are timing out for one client after 5 minutes. Decreasing pageSize for all searches, down from the default/implicit 1000 to more standard 100
- `GetCustomersByIds` endpoint (called from Orders Pull): search for 100 customerId's at a time, to avoid the 1000 api limit for `MultiSelectField`