### PR TITLE
2020-09-08 GUARD-796 Server-Unavailable

### DIFF
--- a/src/NetSuiteAccess/NetSuiteAccess.csproj
+++ b/src/NetSuiteAccess/NetSuiteAccess.csproj
@@ -9,10 +9,10 @@
     <PackageLicenseUrl>https://github.com/skuvault/netsuiteAccess/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skuvault/netsuiteAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault/netsuiteAccess</RepositoryUrl>
-    <Version>1.6.3.0</Version>
+    <Version>1.6.4.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.6.3.0</AssemblyVersion>
-    <FileVersion>1.6.3.0</FileVersion>
+    <AssemblyVersion>1.6.4.0</AssemblyVersion>
+    <FileVersion>1.6.4.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NetSuiteAccess/NetSuiteAccess.csproj
+++ b/src/NetSuiteAccess/NetSuiteAccess.csproj
@@ -9,10 +9,10 @@
     <PackageLicenseUrl>https://github.com/skuvault/netsuiteAccess/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skuvault/netsuiteAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault/netsuiteAccess</RepositoryUrl>
-    <Version>1.6.4.0</Version>
+    <Version>1.6.5.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.6.4.0</AssemblyVersion>
-    <FileVersion>1.6.4.0</FileVersion>
+    <AssemblyVersion>1.6.5.0</AssemblyVersion>
+    <FileVersion>1.6.5.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NetSuiteAccess/Throttling/ActionPolicy.cs
+++ b/src/NetSuiteAccess/Throttling/ActionPolicy.cs
@@ -59,11 +59,13 @@ namespace NetSuiteAccess.Throttling
 
 						if ( exception is HttpRequestException 
 							|| exception is ServerTooBusyException )
+							// wrap exception to retry funcToThrottle using policy
 							netsuiteException = new NetSuiteNetworkException( exceptionDetails, exception );
 						else
 						{
 							netsuiteException = new NetSuiteException( exceptionDetails, exception );
-							onException?.Invoke(netsuiteException);
+							// log exception details
+							onException?.Invoke( netsuiteException );
 						}
 
 						throw netsuiteException;

--- a/src/NetSuiteAccess/Throttling/ActionPolicy.cs
+++ b/src/NetSuiteAccess/Throttling/ActionPolicy.cs
@@ -3,6 +3,7 @@ using NetSuiteAccess.Exceptions;
 using Polly;
 using System;
 using System.Net.Http;
+using System.ServiceModel;
 using System.Threading.Tasks;
 
 namespace NetSuiteAccess.Throttling
@@ -56,7 +57,8 @@ namespace NetSuiteAccess.Throttling
 						if ( extraLogInfo != null )
 							exceptionDetails = extraLogInfo();
 
-						if ( exception is HttpRequestException )
+						if ( exception is HttpRequestException 
+							|| exception is ServerTooBusyException )
 							netsuiteException = new NetSuiteNetworkException( exceptionDetails, exception );
 						else
 						{

--- a/src/NetSuiteTests/ItemTests.cs
+++ b/src/NetSuiteTests/ItemTests.cs
@@ -374,5 +374,27 @@ namespace NetSuiteTests
 			var items = this._itemsService.GetItemsCreatedUpdatedAfterAsync( createOrModifiedDate, true, CancellationToken.None, Mark.Blank() ).Result;
 			items.Count().Should().Be( 0 );
 		}
+
+		[ Test ]
+		[ Ignore( "Run only manually. This test can overload destination server." ) ]
+		public void GivenHugeAmountOfSkus_WhenGetItemBySkuAsyncCalledForEachSku_ThenServerTooBusyExceptionsShouldBeRetried()
+		{
+			var soapService = new NetSuiteSoapService( this.Config );
+			var skus = new List< string >();
+			var totalSkus = 500;
+
+			for (int i = 1; i <= totalSkus; i++)
+			{
+				skus.Add( "testSku-" + i );
+			}
+
+			Assert.DoesNotThrowAsync( async () =>
+			{
+				foreach (var sku in skus)
+				{
+					await soapService.GetItemBySkuAsync( sku, CancellationToken.None );
+				}
+			} );
+		}
 	}
 }


### PR DESCRIPTION
**Summary**

NetSuite server can sometimes throw away client API requests with error "System.ServiceModel.ServerTooBusyException: The HTTP service located at https://<client domain>.suitetalk.api.netsuite.com/services/NetSuitePort_2019_2 is unavailable.  This could be because the service is too busy or because no endpoint was found listening at the specified address. Please ensure that the address is correct and try accessing the service again later".

I have concerns that this behavior can be related to concurrent limits for specific application but for some reason NetSuite server doesn't return standard error codes as it should. 
Here link to the official documentation: 
https://docs.oracle.com/cloud/latest/netsuitecs_gs/NSTWP/NSTWP.pdf (page 21).

I had experienced a little with more common CommunicationException but found out that some derived classes like FaultedException< WrongCredentials > shouldn't be retried. 