### PR TITLE
2020-10-30 GUARD-893 Request-Was-Aborted

### DIFF
--- a/src/NetSuiteAccess/Configuration/NetSuiteConfig.cs
+++ b/src/NetSuiteAccess/Configuration/NetSuiteConfig.cs
@@ -81,7 +81,7 @@ namespace NetSuiteAccess.Configuration
 		{
 			get
 			{
-				return new NetworkOptions( 5 * 60 * 1000, 10, 5, 20 );
+				return new NetworkOptions( 20 * 60 * 1000, 10, 5, 20 );
 			}
 		}
 	}

--- a/src/NetSuiteAccess/Configuration/NetSuiteConfig.cs
+++ b/src/NetSuiteAccess/Configuration/NetSuiteConfig.cs
@@ -12,6 +12,8 @@ namespace NetSuiteAccess.Configuration
 		public readonly NetworkOptions NetworkOptions;
 
 		public int SearchRecordsPageSize { get; set; }
+		public int SearchPurchaseOrdersPageSize { get; set; }
+
 		public static int GetCustomersByIdsPageSize = 100;
 
 		public NetSuiteConfig( NetSuiteCredentials credentials, ThrottlingOptions throttlingOptions, NetworkOptions networkOptions )
@@ -25,6 +27,7 @@ namespace NetSuiteAccess.Configuration
 			this.NetworkOptions = networkOptions;
 			this.ApiBaseUrl = string.Format( "https://{0}.suitetalk.api.netsuite.com", credentials.CustomerId );
 			this.SearchRecordsPageSize = 100;
+			this.SearchPurchaseOrdersPageSize = 50;
 		}
 
 		public NetSuiteConfig( NetSuiteCredentials credentials ) : this( credentials, ThrottlingOptions.NetSuiteDefaultThrottlingOptions, NetworkOptions.NetSuiteDefaultNetworkOptions )
@@ -81,7 +84,7 @@ namespace NetSuiteAccess.Configuration
 		{
 			get
 			{
-				return new NetworkOptions( 50 * 60 * 1000, 10, 5, 20 );
+				return new NetworkOptions( 10 * 60 * 1000, 10, 5, 20 );
 			}
 		}
 	}

--- a/src/NetSuiteAccess/Configuration/NetSuiteConfig.cs
+++ b/src/NetSuiteAccess/Configuration/NetSuiteConfig.cs
@@ -81,7 +81,7 @@ namespace NetSuiteAccess.Configuration
 		{
 			get
 			{
-				return new NetworkOptions( 20 * 60 * 1000, 10, 5, 20 );
+				return new NetworkOptions( 25 * 60 * 1000, 10, 5, 20 );
 			}
 		}
 	}

--- a/src/NetSuiteAccess/Configuration/NetSuiteConfig.cs
+++ b/src/NetSuiteAccess/Configuration/NetSuiteConfig.cs
@@ -81,7 +81,7 @@ namespace NetSuiteAccess.Configuration
 		{
 			get
 			{
-				return new NetworkOptions( 25 * 60 * 1000, 10, 5, 20 );
+				return new NetworkOptions( 50 * 60 * 1000, 10, 5, 20 );
 			}
 		}
 	}

--- a/src/NetSuiteAccess/NetSuiteAccess.csproj
+++ b/src/NetSuiteAccess/NetSuiteAccess.csproj
@@ -9,10 +9,10 @@
     <PackageLicenseUrl>https://github.com/skuvault/netsuiteAccess/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skuvault/netsuiteAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault/netsuiteAccess</RepositoryUrl>
-    <Version>1.6.7.0</Version>
+    <Version>1.6.8.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.6.7.0</AssemblyVersion>
-    <FileVersion>1.6.7.0</FileVersion>
+    <AssemblyVersion>1.6.8.0</AssemblyVersion>
+    <FileVersion>1.6.8.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NetSuiteAccess/NetSuiteAccess.csproj
+++ b/src/NetSuiteAccess/NetSuiteAccess.csproj
@@ -9,10 +9,10 @@
     <PackageLicenseUrl>https://github.com/skuvault/netsuiteAccess/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skuvault/netsuiteAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault/netsuiteAccess</RepositoryUrl>
-    <Version>1.6.8.0</Version>
+    <Version>1.6.9.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.6.8.0</AssemblyVersion>
-    <FileVersion>1.6.8.0</FileVersion>
+    <AssemblyVersion>1.6.9.0</AssemblyVersion>
+    <FileVersion>1.6.9.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NetSuiteAccess/NetSuiteAccess.csproj
+++ b/src/NetSuiteAccess/NetSuiteAccess.csproj
@@ -9,7 +9,7 @@
     <PackageLicenseUrl>https://github.com/skuvault/netsuiteAccess/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skuvault/netsuiteAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault/netsuiteAccess</RepositoryUrl>
-    <Version>1.6.5.0</Version>
+    <Version>1.6.6.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <AssemblyVersion>1.6.6.0</AssemblyVersion>
     <FileVersion>1.6.6.0</FileVersion>

--- a/src/NetSuiteAccess/NetSuiteAccess.csproj
+++ b/src/NetSuiteAccess/NetSuiteAccess.csproj
@@ -11,8 +11,8 @@
     <RepositoryUrl>https://github.com/skuvault/netsuiteAccess</RepositoryUrl>
     <Version>1.6.5.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.6.5.0</AssemblyVersion>
-    <FileVersion>1.6.5.0</FileVersion>
+    <AssemblyVersion>1.6.6.0</AssemblyVersion>
+    <FileVersion>1.6.6.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NetSuiteAccess/NetSuiteAccess.csproj
+++ b/src/NetSuiteAccess/NetSuiteAccess.csproj
@@ -9,10 +9,10 @@
     <PackageLicenseUrl>https://github.com/skuvault/netsuiteAccess/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skuvault/netsuiteAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault/netsuiteAccess</RepositoryUrl>
-    <Version>1.6.9.0</Version>
+    <Version>1.6.10.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.6.9.0</AssemblyVersion>
-    <FileVersion>1.6.9.0</FileVersion>
+    <AssemblyVersion>1.6.10.0</AssemblyVersion>
+    <FileVersion>1.6.10.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NetSuiteAccess/NetSuiteAccess.csproj
+++ b/src/NetSuiteAccess/NetSuiteAccess.csproj
@@ -9,10 +9,10 @@
     <PackageLicenseUrl>https://github.com/skuvault/netsuiteAccess/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skuvault/netsuiteAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault/netsuiteAccess</RepositoryUrl>
-    <Version>1.6.6.0</Version>
+    <Version>1.6.7.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.6.6.0</AssemblyVersion>
-    <FileVersion>1.6.6.0</FileVersion>
+    <AssemblyVersion>1.6.7.0</AssemblyVersion>
+    <FileVersion>1.6.7.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NetSuiteAccess/Services/Soap/NetSuiteSoapService.cs
+++ b/src/NetSuiteAccess/Services/Soap/NetSuiteSoapService.cs
@@ -889,8 +889,9 @@ namespace NetSuiteAccess.Services.Soap
 					if ( currentPageSize == 1 )
 						throw ex;
 
-					currentPageSize = PageAdjuster.GetHalfPageSize( currentPageSize );
-					throw new NetSuiteNetworkException( string.Empty, ex );
+					var prevPageSize = currentPageSize;
+					currentPageSize = PageAdjuster.GetHalfPageSize( prevPageSize );
+					throw new NetSuiteNetworkException( string.Format( "NetSuite server is unable to return entities page using page size {0} with timeout {1} ms! Page size will be decreased to {2}", prevPageSize, _config.NetworkOptions.RequestTimeoutMs, currentPageSize ), ex );
 				}
 
 				return searchResponse;
@@ -944,7 +945,7 @@ namespace NetSuiteAccess.Services.Soap
 						currentPageSize = PageAdjuster.GetHalfPageSize( currentPageSize );
 						pageIndex = PageAdjuster.GetNextPageIndex( prevPageInfo, currentPageSize );
 
-						throw new NetSuiteNetworkException( string.Empty, ex );
+						throw new NetSuiteNetworkException( string.Format( "NetSuite server is unable to return entities page {0} using page size {1} with timeout {2} ms! New page index will be {3}, new page size will decreased to {4}.", prevPageInfo.Index, prevPageInfo.Size, _config.NetworkOptions.RequestTimeoutMs, pageIndex, currentPageSize ), ex );
 					}
 
 					return pageResponse;

--- a/src/NetSuiteAccess/Services/Soap/NetSuiteSoapService.cs
+++ b/src/NetSuiteAccess/Services/Soap/NetSuiteSoapService.cs
@@ -882,7 +882,7 @@ namespace NetSuiteAccess.Services.Soap
 						pageSizeSpecified = true
 					};
 
-					searchResponse = await this._service.searchAsync( null, this._passport, null, null, searchPreferences, searchRecord );
+					searchResponse = await this._service.searchAsync( null, this._passport, null, null, searchPreferences, searchRecord ).ConfigureAwait( false );
 				}
 				catch( TimeoutException ex )
 				{
@@ -933,7 +933,7 @@ namespace NetSuiteAccess.Services.Soap
 							pageSize = currentPageSize,
 							pageSizeSpecified = true
 						};
-						pageResponse = await this._service.searchMoreWithIdAsync( null, this._passport, null, null, searchPreferences, searchId, pageIndex );
+						pageResponse = await this._service.searchMoreWithIdAsync( null, this._passport, null, null, searchPreferences, searchId, pageIndex ).ConfigureAwait( false );
 					}
 					catch( TimeoutException ex )
 					{

--- a/src/NetSuiteAccess/Services/Soap/NetSuiteSoapService.cs
+++ b/src/NetSuiteAccess/Services/Soap/NetSuiteSoapService.cs
@@ -808,12 +808,12 @@ namespace NetSuiteAccess.Services.Soap
 			{
 				lastModifiedDate = new SearchDateField()
 				{
-						@operator = SearchDateFieldOperator.within,
-						operatorSpecified = true,
-						searchValue = startDateUtc.ToUniversalTime(),
-						searchValueSpecified = true,
-						searchValue2 = endDateUtc.ToUniversalTime(),
-						searchValue2Specified = true
+					@operator = SearchDateFieldOperator.within,
+					operatorSpecified = true,
+					searchValue = startDateUtc.ToUniversalTime(),
+					searchValueSpecified = true,
+					searchValue2 = endDateUtc.ToUniversalTime(),
+					searchValue2Specified = true
 				},
 				recordType = new SearchStringField()
 				{
@@ -823,7 +823,7 @@ namespace NetSuiteAccess.Services.Soap
 				},
 			};
 
-			var response = await this.SearchRecords( purchaseOrdersSearchRequest, mark, cancellationToken ).ConfigureAwait( false );
+			var response = await this.SearchRecords( purchaseOrdersSearchRequest, mark, cancellationToken, _config.SearchPurchaseOrdersPageSize ).ConfigureAwait( false );
 			return response.OfType< NetSuiteSoapWS.PurchaseOrder >().Select( p => p.ToSVPurchaseOrder() );
 		}
 
@@ -864,19 +864,37 @@ namespace NetSuiteAccess.Services.Soap
 			return response.OfType< NetSuiteSoapWS.SalesOrder >().Select( p => p.ToSVSalesOrder() );
 		}
 
-		private async Task< IEnumerable< Record > > SearchRecords( SearchRecord searchRecord, Mark mark, CancellationToken cancellationToken )
+		private async Task< IEnumerable< Record > > SearchRecords( SearchRecord searchRecord, Mark mark, CancellationToken cancellationToken, int? pageSize = null )
 		{
 			var result = new List< Record >();
-			var response = await this.ThrottleRequestAsync( mark, ( token ) =>
+			var currentPageSize = pageSize ?? _config.SearchRecordsPageSize;
+			
+			var response = await this.ThrottleRequestAsync( mark, async ( token ) =>
 			{
-				var searchPreferences = new SearchPreferences
+				searchResponse searchResponse = null;
+				
+				try
 				{
-					bodyFieldsOnly = false,
-					pageSize = _config.SearchRecordsPageSize,
-					pageSizeSpecified = true
-				};
+					var searchPreferences = new SearchPreferences
+					{
+						bodyFieldsOnly = false,
+						pageSize = currentPageSize,
+						pageSizeSpecified = true
+					};
 
-				return this._service.searchAsync( null, this._passport, null, null, searchPreferences, searchRecord );
+					searchResponse = await this._service.searchAsync( null, this._passport, null, null, searchPreferences, searchRecord );
+				}
+				catch( TimeoutException ex )
+				{
+					if ( currentPageSize == 1 )
+						throw ex;
+
+					currentPageSize = PageAdjuster.GetHalfPageSize( currentPageSize );
+					throw new NetSuiteNetworkException( string.Empty, ex );
+				}
+
+				return searchResponse;
+				
 			}, searchRecord.ToJson(), cancellationToken ).ConfigureAwait( false );
 
 			var searchResult = response.searchResult;
@@ -886,7 +904,7 @@ namespace NetSuiteAccess.Services.Soap
 
 				if ( searchResult.totalPages > 1 )
 				{
-					result.AddRange( await this.CollectDataFromExtraPages< Record >( searchResult.searchId, searchResult.totalPages ).ConfigureAwait( false ) );
+					result.AddRange( await this.CollectDataFromExtraPages< Record >( searchResult.searchId, searchResult.totalPages, currentPageSize, cancellationToken, mark ).ConfigureAwait( false ) );
 				}
 
 				return result;
@@ -895,14 +913,46 @@ namespace NetSuiteAccess.Services.Soap
 			throw new NetSuiteException( response.searchResult.status.statusDetail[0].message );
 		}
 
-		private async Task< IEnumerable< T > > CollectDataFromExtraPages< T >( string searchId, int totalPages )
+		private async Task< IEnumerable< T > > CollectDataFromExtraPages< T >( string searchId, int totalPages, int pageSize, CancellationToken cancellationToken, Mark mark )
 		{
 			var result = new List< T >();
 			int pageIndex = 2;
+			int currentPageSize = pageSize;
+
 			while ( pageIndex <= totalPages )
 			{
-				var searchMoreResponse = await this._service.searchMoreWithIdAsync( null, this._passport, null, null, null, searchId, pageIndex ).ConfigureAwait( false );
+				var searchMoreResponse = await this.ThrottleRequestAsync( mark, async ( token ) =>
+				{
+					searchMoreWithIdResponse pageResponse = null;
+
+					try
+					{
+						var searchPreferences = new SearchPreferences()
+						{
+							pageSize = currentPageSize,
+							pageSizeSpecified = true
+						};
+						pageResponse = await this._service.searchMoreWithIdAsync( null, this._passport, null, null, searchPreferences, searchId, pageIndex );
+					}
+					catch( TimeoutException ex )
+					{
+						if ( currentPageSize == 1 )
+							throw ex;
+
+						// decrease page size and change page index
+						var prevPageInfo = new PageInfo( pageIndex, currentPageSize );
+						currentPageSize = PageAdjuster.GetHalfPageSize( currentPageSize );
+						pageIndex = PageAdjuster.GetNextPageIndex( prevPageInfo, currentPageSize );
+
+						throw new NetSuiteNetworkException( string.Empty, ex );
+					}
+
+					return pageResponse;
+
+				}, searchId, cancellationToken ).ConfigureAwait( false );
+				
 				++pageIndex;
+				totalPages = searchMoreResponse.searchResult.totalPages;
 
 				if ( !searchMoreResponse.searchResult.status.isSuccess )
 				{

--- a/src/NetSuiteAccess/Shared/PageAdjuster.cs
+++ b/src/NetSuiteAccess/Shared/PageAdjuster.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+namespace NetSuiteAccess.Shared
+{
+	public class PageAdjuster
+	{
+		public static int GetHalfPageSize( int currentPageSize )
+		{
+			return Math.Max( (int)Math.Floor( currentPageSize / 2d ), 1 );
+		}
+
+		public static int GetNextPageIndex( PageInfo currentPageInfo, int newPageSize )
+		{
+			var entitiesReceived = currentPageInfo.Size * ( currentPageInfo.Index - 1 );
+			return (int)Math.Floor( entitiesReceived * 1.0 / newPageSize ) + 1;
+		}
+	}
+
+	public struct PageInfo
+	{
+		public PageInfo( int index, int size )
+		{
+			this.Index = index;
+			this.Size = size;
+		}
+
+		public int Index { get; set; }
+		public int Size { get; set; }
+	}
+}

--- a/src/NetSuiteAccess/Throttling/ActionPolicy.cs
+++ b/src/NetSuiteAccess/Throttling/ActionPolicy.cs
@@ -51,6 +51,9 @@ namespace NetSuiteAccess.Throttling
 					}
 					catch ( Exception exception )
 					{
+						if ( exception is NetSuiteNetworkException )
+							throw exception;
+
 						NetSuiteException netsuiteException = null;
 						var exceptionDetails = string.Empty;
 

--- a/src/NetSuiteTests/NetSuiteTests.csproj
+++ b/src/NetSuiteTests/NetSuiteTests.csproj
@@ -76,6 +76,7 @@
     <Compile Include="LocationMapperTests.cs" />
     <Compile Include="OrderMapperTests.cs" />
     <Compile Include="OrderTests.cs" />
+    <Compile Include="PageAdjusterTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestCredentials.cs" />
   </ItemGroup>

--- a/src/NetSuiteTests/OrderTests.cs
+++ b/src/NetSuiteTests/OrderTests.cs
@@ -1,5 +1,6 @@
 ﻿using FluentAssertions;
 using NetSuiteAccess;
+using NetSuiteAccess.Exceptions;
 using NetSuiteAccess.Models;
 using NetSuiteAccess.Services.Orders;
 using NUnit.Framework;
@@ -52,6 +53,18 @@ namespace NetSuiteTests
 			Config.SearchRecordsPageSize = 5;
 			var purchaseOrders = this._ordersService.GetPurchaseOrdersAsync( DateTime.UtcNow.AddMonths( -1 ), DateTime.UtcNow, CancellationToken.None ).Result;
 			purchaseOrders.Count().Should().BeGreaterThan( 0 );
+		}
+
+		[ Test ]
+		public void GivenHugeDefaultPurchaseOrdersPageSize_WhenGetPurchaseOrdersAsyncIsCalled_ThenExceptionIsNotExpected()
+		{
+			Config.SearchPurchaseOrdersPageSize = 200;
+
+			var ex = Assert.Throws< NetSuiteException >( () =>
+			{
+				this._ordersService.GetPurchaseOrdersAsync( DateTime.UtcNow.AddDays( -14 ), DateTime.UtcNow, CancellationToken.None ).Wait();
+			} );
+			ex.Should().BeNull();
 		}
 
 		[ Test ]

--- a/src/NetSuiteTests/OrderTests.cs
+++ b/src/NetSuiteTests/OrderTests.cs
@@ -42,7 +42,7 @@ namespace NetSuiteTests
 		[ Test ]
 		public void GetModifiedPurchaseOrders()
 		{
-			var purchaseOrders = this._ordersService.GetPurchaseOrdersAsync( DateTime.UtcNow.AddMonths( -1 ), DateTime.UtcNow, CancellationToken.None ).Result;
+			var purchaseOrders = this._ordersService.GetPurchaseOrdersAsync( DateTime.UtcNow.AddDays( -14 ), DateTime.UtcNow, CancellationToken.None ).Result;
 			purchaseOrders.Count().Should().BeGreaterThan( 0 );
 		}
 

--- a/src/NetSuiteTests/PageAdjusterTests.cs
+++ b/src/NetSuiteTests/PageAdjusterTests.cs
@@ -1,0 +1,54 @@
+﻿using FluentAssertions;
+using NetSuiteAccess.Shared;
+using NUnit.Framework;
+
+namespace NetSuiteTests
+{
+	[ TestFixture ]
+	public class PageAdjusterTests
+	{
+		private const int DefaultPageSize = 250;
+		private const int MinPageSize = 1;
+
+		[ Test ]
+		public void GivenPageWithDefaultSize_WhenGetHalfPageCalled_ThenHalfPageSizeIsReturned()
+		{
+			var currentPageSize = DefaultPageSize;
+			var newPageSize = PageAdjuster.GetHalfPageSize( currentPageSize );
+			newPageSize.Should().Be( DefaultPageSize / 2 );
+		}
+
+		[ Test ]
+		public void GivenPageWithMinPage_WhenGetHalfPageCalled_ThenSamePageSizeIsReturned()
+		{
+			var currentPageSize = 1;
+			var newPageSize = PageAdjuster.GetHalfPageSize( currentPageSize );
+			newPageSize.Should().Be( currentPageSize );
+		}
+
+		[ Test ]
+		public void GivenFirstPageWithHalfPageExpected_WhenGetNextPageIndexCalled_ThenNextPageIndexIsTheSame()
+		{
+			var firstPageIndex = 1;
+			var newPageIndex = PageAdjuster.GetNextPageIndex( new PageInfo( firstPageIndex, DefaultPageSize ), 125 );
+			newPageIndex.Should().Be( firstPageIndex );
+		}
+
+		[ Test ]
+		public void GivenPageWithHalfPageExpected_WhenGetNextPageIndexCalled_ThenNextPageIndexIsRecalculatedCorrectly()
+		{
+			var currentPageIndex = 5;
+			var newPageIndex = PageAdjuster.GetNextPageIndex( new PageInfo( currentPageIndex, DefaultPageSize ), 125 );
+			newPageIndex.Should().Be( currentPageIndex * 2 - 1 );
+		}
+
+		[ Test ]
+		public void GivenPageWithHalfPageExpectedAndNotDefaultCurrentPage_WhenGetNextPageIndexCalled_ThenNextPageIndexIsRecalculatedCorrectly()
+		{
+			var currentPageIndex = 5;
+			var currentPageSize = 125;
+			var newPageIndex = PageAdjuster.GetNextPageIndex( new PageInfo( currentPageIndex, currentPageSize ), 62 );
+			newPageIndex.Should().Be( currentPageIndex * 2 - 1 );
+		}
+	}
+}

--- a/src/NetSuiteTests/PageAdjusterTests.cs
+++ b/src/NetSuiteTests/PageAdjusterTests.cs
@@ -11,7 +11,7 @@ namespace NetSuiteTests
 		private const int MinPageSize = 1;
 
 		[ Test ]
-		public void GivenPageWithDefaultSize_WhenGetHalfPageCalled_ThenHalfPageSizeIsReturned()
+		public void GivenPageWithDefaultPageSize_WhenGetHalfPageSizeIsCalled_ThenHalfPageSizeIsReturned()
 		{
 			var currentPageSize = DefaultPageSize;
 			var newPageSize = PageAdjuster.GetHalfPageSize( currentPageSize );
@@ -19,7 +19,7 @@ namespace NetSuiteTests
 		}
 
 		[ Test ]
-		public void GivenPageWithMinPage_WhenGetHalfPageCalled_ThenSamePageSizeIsReturned()
+		public void GivenPageWithMinPageSize_WhenGetHalfPageSizeIsCalled_ThenSamePageSizeIsReturned()
 		{
 			var currentPageSize = 1;
 			var newPageSize = PageAdjuster.GetHalfPageSize( currentPageSize );
@@ -27,7 +27,7 @@ namespace NetSuiteTests
 		}
 
 		[ Test ]
-		public void GivenFirstPageWithHalfPageExpected_WhenGetNextPageIndexCalled_ThenNextPageIndexIsTheSame()
+		public void GivenPageWithFirstIndex_WhenGetNextPageIndexWithDecreasedPageSizeTwiceIsCalled_ThenNextPageIndexIsTheSame()
 		{
 			var firstPageIndex = 1;
 			var newPageIndex = PageAdjuster.GetNextPageIndex( new PageInfo( firstPageIndex, DefaultPageSize ), 125 );
@@ -35,7 +35,7 @@ namespace NetSuiteTests
 		}
 
 		[ Test ]
-		public void GivenPageWithHalfPageExpected_WhenGetNextPageIndexCalled_ThenNextPageIndexIsRecalculatedCorrectly()
+		public void GivenPageWithIndexHigherThanFirst_WhenGetNextPageIndexWithDecreasedPageSizeTwiceIsCalled_ThenNextPageIndexIsRecalculatedCorrectly()
 		{
 			var currentPageIndex = 5;
 			var newPageIndex = PageAdjuster.GetNextPageIndex( new PageInfo( currentPageIndex, DefaultPageSize ), 125 );
@@ -43,11 +43,12 @@ namespace NetSuiteTests
 		}
 
 		[ Test ]
-		public void GivenPageWithHalfPageExpectedAndNotDefaultCurrentPage_WhenGetNextPageIndexCalled_ThenNextPageIndexIsRecalculatedCorrectly()
+		public void GivenPageWithDecreasedTwiceDefaultPageSize_WhenGetNextPageIndexWithDecreasedPageSizeTwiceIsCalled_ThenNextPageIndexIsCalculatedCorrectly()
 		{
 			var currentPageIndex = 5;
-			var currentPageSize = 125;
-			var newPageIndex = PageAdjuster.GetNextPageIndex( new PageInfo( currentPageIndex, currentPageSize ), 62 );
+			var currentPageSize = DefaultPageSize / 2;
+			var halfPageSize = currentPageSize / 2;
+			var newPageIndex = PageAdjuster.GetNextPageIndex( new PageInfo( currentPageIndex, currentPageSize ), halfPageSize );
 			newPageIndex.Should().Be( currentPageIndex * 2 - 1 );
 		}
 	}


### PR DESCRIPTION
**Summary**
Current SendTimeout value for SOAP client is not enough to pull all purchase orders from MFI Medicals's NetSuite account.
https://docs.microsoft.com/en-us/dotnet/api/system.servicemodel.channels.binding.sendtimeout?view=dotnet-plat-ext-3.1

After increasing this value to 20 minutes, successfully pulled all purchase orders (~900).