### PR TITLE
2020-11-25 GUARD-906 Unable-To-Create-Purchase-Order

### DIFF
--- a/src/NetSuiteAccess/Models/PurchaseOrder.cs
+++ b/src/NetSuiteAccess/Models/PurchaseOrder.cs
@@ -30,7 +30,7 @@ namespace NetSuiteAccess.Models
 	{
 		Unknown,
 		PendingReceipt,
-		PendingBill,
+		PendingBilling,
 		PartiallyReceived,
 		PendingBillingPartiallyReceived,
 		FullyBilled,
@@ -48,7 +48,7 @@ namespace NetSuiteAccess.Models
 			PurchaseOrderStatuses = new Dictionary< string, NetSuitePurchaseOrderStatus >()
 			{
 				{ "Pending Receipt", NetSuitePurchaseOrderStatus.PendingReceipt },
-				{ "Pending Bill", NetSuitePurchaseOrderStatus.PendingBill },
+				{ "Pending Billing", NetSuitePurchaseOrderStatus.PendingBilling },
 				{ "Partially Received", NetSuitePurchaseOrderStatus.PartiallyReceived },
 				{ "Pending Billing/Partially Received", NetSuitePurchaseOrderStatus.PendingBillingPartiallyReceived },
 				{ "Fully Billed", NetSuitePurchaseOrderStatus.FullyBilled },

--- a/src/NetSuiteAccess/NetSuiteAccess.csproj
+++ b/src/NetSuiteAccess/NetSuiteAccess.csproj
@@ -9,10 +9,10 @@
     <PackageLicenseUrl>https://github.com/skuvault/netsuiteAccess/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skuvault/netsuiteAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault/netsuiteAccess</RepositoryUrl>
-    <Version>1.6.5.0</Version>
+    <Version>1.6.11.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.6.5.0</AssemblyVersion>
-    <FileVersion>1.6.5.0</FileVersion>
+    <AssemblyVersion>1.6.11.0</AssemblyVersion>
+    <FileVersion>1.6.11.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
**Summary**
Following NetSuite documentation, renamed "pending bill" purchase order status to "pending billing".

https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2019_2/schema/enum/purchaseorderorderstatus.html?mode=package